### PR TITLE
Feature/Add in looker pr template

### DIFF
--- a/etc/lookml-projects/.github/pull_request_template.md
+++ b/etc/lookml-projects/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+<!--- Provide a short summary in the Title above -->
+<!--- Examples of good PR titles: "Feature: add orders view"; "Fix: remove depreciated dimension" -->
+
+## Notes/Limitations/Next Steps
+<!--- Describe your changes in detail including any potential issues. -->
+<!--- Is this linked to an open issue or another pull request that needs to be 
+merged in prior? Link it here. -->
+
+## Checklist:
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+<!--- Remove any boxes that are not relevant -->
+
+- [ ] I ran the Content Validator and validated my changes in my LookML. 
+- [ ] My commits are related to the pull request and look clean. 
+- [ ] My views and models are organized. 
+- [ ] I have type casted my dimensions appropriately.
+- [ ] I have set up the appropriate prod and dev mode.


### PR DESCRIPTION
This adds in a simple looker pull request template for projects that have Looker. The template is for Looker set ups that require a pull request to merge into production and have all LookML errors fixed prior to committing. 