### PR TITLE
Feature: postgres/redshift multiple group grants

### DIFF
--- a/starter-project/dbt_project.yml
+++ b/starter-project/dbt_project.yml
@@ -28,8 +28,7 @@ models:
   bind: false
 
 on-run-end:
-  - {% raw %}"{{ grant_select_on_schemas(schemas, 'reporter') }}"{% endraw %}
-  - {% raw %}"{{ grant_select_on_schemas(schemas, 'transformer') }}"{% endraw %}
+  - {% raw %}"{{ grant_select_on_schemas(schemas, ['transformer','reporter']) }}"{% endraw %}
 
 {% elif project.warehouse == 'snowflake' %}
 

--- a/starter-project/macros/grant_select_on_schemas.sql
+++ b/starter-project/macros/grant_select_on_schemas.sql
@@ -1,11 +1,12 @@
 {% if project.warehouse in ('postgres', 'redshift') %}
 {% raw %}
 {% macro grant_select_on_schemas(schemas, groups) %}
+  {% set groups_csv = 'group' ~  groups | join(', group ') %}
   {% for schema in schemas %}
-    grant usage on schema {{ schema }} to group {{ groups|join(', group ') }};
-    grant select on all tables in schema {{ schema }} to group {{ groups|join(', group ') }};
+    grant usage on schema {{ schema }} to group {{ groups_csv }};
+    grant select on all tables in schema {{ schema }} to group {{ groups_csv }};
     alter default privileges in schema {{ schema }}
-        grant select on tables to group {{ groups|join(', group ') }};
+        grant select on tables to group {{ groups_csv }};
   {% endfor %}
 {% endmacro %}
 {% endraw %}

--- a/starter-project/macros/grant_select_on_schemas.sql
+++ b/starter-project/macros/grant_select_on_schemas.sql
@@ -1,11 +1,11 @@
 {% if project.warehouse in ('postgres', 'redshift') %}
 {% raw %}
-{% macro grant_select_on_schemas(schemas, group) %}
+{% macro grant_select_on_schemas(schemas, groups) %}
   {% for schema in schemas %}
-    grant usage on schema {{ schema }} to group {{ group }};
-    grant select on all tables in schema {{ schema }} to group {{ group }};
+    grant usage on schema {{ schema }} to group {{ groups|join(', group ') }};
+    grant select on all tables in schema {{ schema }} to group {{ groups|join(', group ') }};
     alter default privileges in schema {{ schema }}
-        grant select on tables to group {{ group }};
+        grant select on tables to group {{ groups|join(', group ') }};
   {% endfor %}
 {% endmacro %}
 {% endraw %}


### PR DESCRIPTION
This change is cosmetic/vanity only. On Redshift + Postgres, you can run the following:
```
    grant usage on schema dbt_jcohen to group transformer, group reporter;
    grant select on all tables in schema dbt_jcohen to group transformer, group reporter;
    alter default privileges in schema dbt_jcohen
        grant select on tables to group transformer, group reporter;
```
I'd understand if you prefer the more explicit/repeated version.