### PR TITLE
Feature/better args

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,25 +19,25 @@ jobs:
           command: |
             mkdir jaffle_shop_bigquery
             . venv/bin/activate
-            dbt-init --client jaffle_shop --warehouse bigquery --target-dir ./jaffle_shop_bigquery
+            dbt-init --client jaffle-shop --warehouse bigquery --target-dir ./jaffle_shop_bigquery
       - run:
           name: "Create Starter Project - Postgres"
           command: |
             mkdir jaffle_shop_postgres
             . venv/bin/activate
-            dbt-init --client jaffle_shop --warehouse postgres --target-dir ./jaffle_shop_postgres
+            dbt-init --client jaffle-shop --warehouse postgres --target-dir ./jaffle_shop_postgres
       - run:
           name: "Create Starter Project - Redshift"
           command: |
             mkdir jaffle_shop_redshift
             . venv/bin/activate
-            dbt-init --client jaffle_shop --warehouse redshift --target-dir ./jaffle_shop_redshift
+            dbt-init --client jaffle-shop --warehouse redshift --target-dir ./jaffle_shop_redshift
       - run:
           name: "Create Starter Project - Snowflake"
           command: |
             mkdir jaffle_shop_snowflake
             . venv/bin/activate
-            dbt-init --client jaffle_shop --warehouse snowflake --target-dir ./jaffle_shop_snowflake
+            dbt-init --client jaffle-shop --warehouse snowflake --target-dir ./jaffle_shop_snowflake
       - save_cache:
           key: deps1-{{ .Branch }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,25 +19,25 @@ jobs:
           command: |
             mkdir jaffle_shop_bigquery
             . venv/bin/activate
-            dbt-init --client jaffle_shop --warehouse bigquery --target_dir ./jaffle_shop_bigquery
+            dbt-init --client jaffle_shop --warehouse bigquery --target-dir ./jaffle_shop_bigquery
       - run:
           name: "Create Starter Project - Postgres"
           command: |
             mkdir jaffle_shop_postgres
             . venv/bin/activate
-            dbt-init --client jaffle_shop --warehouse postgres --target_dir ./jaffle_shop_postgres
+            dbt-init --client jaffle_shop --warehouse postgres --target-dir ./jaffle_shop_postgres
       - run:
           name: "Create Starter Project - Redshift"
           command: |
             mkdir jaffle_shop_redshift
             . venv/bin/activate
-            dbt-init --client jaffle_shop --warehouse redshift --target_dir ./jaffle_shop_redshift
+            dbt-init --client jaffle_shop --warehouse redshift --target-dir ./jaffle_shop_redshift
       - run:
           name: "Create Starter Project - Snowflake"
           command: |
             mkdir jaffle_shop_snowflake
             . venv/bin/activate
-            dbt-init --client jaffle_shop --warehouse snowflake --target_dir ./jaffle_shop_snowflake
+            dbt-init --client jaffle_shop --warehouse snowflake --target-dir ./jaffle_shop_snowflake
       - save_cache:
           key: deps1-{{ .Branch }}
           paths:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ provide it, and populate as much of the dbt project as possible
 1. Install using `pip install dbt-init`
 2. To create a new client project run a command like following:
 ```bash
-$ dbt-init --client jaffle_shop --warehouse snowflake --target_dir ~/clients/
+$ dbt-init --client jaffle_shop --warehouse snowflake --target-dir ~/clients/
 ```
 You can also check the available arguments with `dbt-init --help`
 
@@ -43,7 +43,7 @@ your virtual environment uses python 3.
 changes by creating a sample project and inspecting the results (I know, we
 should build real tests), e.g.:
 ```
-$ dbt-init --client test --target_dir ~/clrcrl/ --warehouse bigquery
+$ dbt-init --client test --target-dir ~/clrcrl/ --warehouse bigquery
 New dbt project for test created at /Users/claire/clrcrl/test-dbt! 🎉
 
 $ open /Users/claire/clrcrl/test-dbt

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ provide it, and populate as much of the dbt project as possible
 1. Install using `pip install dbt-init`
 2. To create a new client project run a command like following:
 ```bash
-$ dbt-init --client jaffle_shop --warehouse snowflake --target-dir ~/clients/
+$ dbt-init --client jaffle-shop --warehouse snowflake --target-dir ~/clients/
 ```
 You can also check the available arguments with `dbt-init --help`
 
@@ -26,7 +26,7 @@ variables you can use – a lot of them have defaults based on the client name.
 ```
 {{ project.name }}: The name of the project, as defined in `dbt_project.yml`, e.g. jaffle_shop.
 {{ project.warehouse }}: The warehouse that a client is using.
-{{ project.client_name }}: The name of the client, e.g. jaffle_shop.
+{{ project.client_name }}: The name of the client, e.g. jaffle-shop.
 {{ project.dir_name }}: The name of the directory this project is in, e.g. jaffle-shop-dbt.
 {{ project.profile_name }}: The name of the profile used by this project, e.g. jaffle_shop.
 ```

--- a/core/main.py
+++ b/core/main.py
@@ -50,7 +50,16 @@ def parse_args(args):
     required.add_argument(
         "--warehouse",
         required=True,
-        choices=["bigquery", "postgres", "redshift", "snowflake"],
+        choices=[
+            "bigquery",
+            "bq",
+            "postgres",
+            "pg",
+            "redshift",
+            "rs",
+            "snowflake",
+            "sf",
+        ],
         help="The warehouse your client is using",
     )
     required.add_argument(
@@ -89,7 +98,7 @@ def handle(parsed):
     project = {}
 
     project["client_name"] = parsed.client
-    project["warehouse"] = parsed.warehouse
+    project["warehouse"] = map_warehouse(parsed.warehouse)
     project["name"] = parsed.project_name or parsed.client
     project["dir_path"] = parsed.target_dir
     project["dir_name"] = parsed.project_directory or "{}-dbt".format(kebab_case_client)
@@ -120,6 +129,17 @@ def check_file_path(s):
     if not os.path.exists(s):
         raise ArgumentTypeError("Target directory {} does not exist!".format(s))
     return s
+
+
+def map_warehouse(s):
+    mapping_dict = {
+        "bq": "bigquery",
+        "rs": "redshift",
+        "sf": "snowflake",
+        "pg": "postgres",
+    }
+
+    return mapping_dict.get(s, s)
 
 
 def should_copy_file(base_name, contents):

--- a/core/main.py
+++ b/core/main.py
@@ -8,7 +8,7 @@ import re
 import jinja2
 
 
-STARTER_PROJECT_DIR_PATH =  Path(__file__).parents[1]
+STARTER_PROJECT_DIR_PATH = Path(__file__).parents[1]
 STARTER_PROJECT_DIR = "starter-project"
 STARTER_PROJECT_PATH = os.path.join(STARTER_PROJECT_DIR_PATH, STARTER_PROJECT_DIR)
 
@@ -129,11 +129,13 @@ def create_starter_project(project):
     client_project_path = os.path.join(project["dir_path"], project["dir_name"])
     # for each file in the starter project, copy a rendered version of the file
     for subdir, dirs, files in os.walk(STARTER_PROJECT_PATH):
-        if os.path.basename(subdir) != '__pycache__':
+        if os.path.basename(subdir) != "__pycache__":
             for base_name in files:
                 rendered_template = render_template(subdir, base_name, project)
                 if should_copy_file(base_name, rendered_template):
-                    target_dir = subdir.replace(STARTER_PROJECT_PATH, client_project_path)
+                    target_dir = subdir.replace(
+                        STARTER_PROJECT_PATH, client_project_path
+                    )
                     target_filepath = os.path.join(target_dir, base_name)
                     write_file(target_filepath, rendered_template)
 

--- a/core/main.py
+++ b/core/main.py
@@ -37,35 +37,39 @@ def write_file(file_path, contents):
 
 def parse_args(args):
     parser = ArgumentParser(description="dbt project starter")
-    parser.add_argument(
+    parser._action_groups.pop()
+    required = parser.add_argument_group("required arguments")
+    optional = parser.add_argument_group("optional arguments")
+
+    required.add_argument(
         "--client",
         required=True,
         help="The name of the client you are creating this project for",
         type=check_snake_case,
     )
-    parser.add_argument(
+    required.add_argument(
         "--warehouse",
         required=True,
         choices=["bigquery", "postgres", "redshift", "snowflake"],
         help="The warehouse your client is using",
     )
-    parser.add_argument(
+    required.add_argument(
         "--target_dir",
         required=True,
         help="The target directory name. Note that the project will be created as a subdirectory within the target directory",
         type=check_file_path,
     )
-    parser.add_argument(
+    optional.add_argument(
         "--project_name",
         help="The name of your dbt project (as defined in dbt_project.yml). Defaults to <my_client>",
         type=check_snake_case,
     )
-    parser.add_argument(
+    optional.add_argument(
         "--project_directory",
         help="The name of your dbt project directory. Defaults to <my-client>-dbt",
         type=check_kebab_case,
     )
-    parser.add_argument(
+    optional.add_argument(
         "--profile_name",
         help="The name of the profile your dbt project will use. Defaults to <my_client>",
         type=check_snake_case,

--- a/core/main.py
+++ b/core/main.py
@@ -63,23 +63,23 @@ def parse_args(args):
         help="The warehouse your client is using",
     )
     required.add_argument(
-        "--target_dir",
+        "--target-dir",
         required=True,
         help="The target directory name. Note that the project will be created as a subdirectory within the target directory",
         type=check_file_path,
     )
     optional.add_argument(
-        "--project_name",
+        "--project-name",
         help="The name of your dbt project (as defined in dbt_project.yml). Defaults to <my_client>",
         type=check_snake_case,
     )
     optional.add_argument(
-        "--project_directory",
+        "--project-directory",
         help="The name of your dbt project directory. Defaults to <my-client>-dbt",
         type=check_kebab_case,
     )
     optional.add_argument(
-        "--profile_name",
+        "--profile-name",
         help="The name of the profile your dbt project will use. Defaults to <my_client>",
         type=check_snake_case,
     )

--- a/core/main.py
+++ b/core/main.py
@@ -45,7 +45,7 @@ def parse_args(args):
         "--client",
         required=True,
         help="The name of the client you are creating this project for",
-        type=check_snake_case,
+        type=check_kebab_case,
     )
     required.add_argument(
         "--warehouse",
@@ -93,16 +93,17 @@ def handle(parsed):
     describes the dbt project
     """
 
-    kebab_case_client = parsed.client.replace("_", "-")
+    client_kebab_case = parsed.client
+    client_snake_case = client_kebab_case.replace("-", "_")
 
     project = {}
 
-    project["client_name"] = parsed.client
+    project["client_name"] = client_kebab_case
     project["warehouse"] = map_warehouse(parsed.warehouse)
-    project["name"] = parsed.project_name or parsed.client
+    project["name"] = parsed.project_name or client_snake_case
     project["dir_path"] = parsed.target_dir
-    project["dir_name"] = parsed.project_directory or "{}-dbt".format(kebab_case_client)
-    project["profile_name"] = parsed.profile_name or parsed.client
+    project["dir_name"] = parsed.project_directory or "{}-dbt".format(client_kebab_case)
+    project["profile_name"] = parsed.profile_name or client_snake_case
 
     return project
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@
 ipdb
 twine
 wheel
+black

--- a/setup.py
+++ b/setup.py
@@ -40,9 +40,7 @@ setup(
     author_email="claire@fishtownanalytics.com",
     url="https://github.com/fishtown-analyics/dbt-init",
     packages=find_packages(),
-    package_data={
-        '': ['starter-project/**/*']
-    },
+    package_data={"": ["starter-project/**/*"]},
     include_package_data=True,
     test_suite="test",
     entry_points={"console_scripts": ["dbt-init = core.main:main"]},


### PR DESCRIPTION
Ton of tiny improvements just to make things easier to type. Commits are pretty clean, so no need to go into depth except for this one:

**Make required named arguments appear under required list**
Before:
```
 $ dbt-init --help
usage: dbt-init [-h] --client CLIENT --warehouse
                {bigquery,postgres,redshift,snowflake} --target_dir TARGET_DIR
                [--project_name PROJECT_NAME]
                [--project_directory PROJECT_DIRECTORY]
                [--profile_name PROFILE_NAME]

dbt project starter

optional arguments:
  -h, --help            show this help message and exit
  --client CLIENT       The name of the client you are creating this project
                        for
  --warehouse {bigquery,postgres,redshift,snowflake}
                        The warehouse your client is using
  --target_dir TARGET_DIR
                        The target directory name. Note that the project will
                        be created as a subdirectory within the target
                        directory
  --project_name PROJECT_NAME
                        The name of your dbt project (as defined in
                        dbt_project.yml). Defaults to <my_client>
  --project_directory PROJECT_DIRECTORY
                        The name of your dbt project directory. Defaults to
                        <my-client>-dbt
  --profile_name PROFILE_NAME
                        The name of the profile your dbt project will use.
                        Defaults to <my_client>
```
After:
```
 $ dbt-init --help
usage: dbt-init [-h] --client CLIENT --warehouse
                {bigquery,bq,postgres,pg,redshift,rs,snowflake,sf}
                --target-dir TARGET_DIR [--project-name PROJECT_NAME]
                [--project-directory PROJECT_DIRECTORY]
                [--profile-name PROFILE_NAME]

dbt project starter

required arguments:
  --client CLIENT       The name of the client you are creating this project
                        for
  --warehouse {bigquery,bq,postgres,pg,redshift,rs,snowflake,sf}
                        The warehouse your client is using
  --target-dir TARGET_DIR
                        The target directory name. Note that the project will
                        be created as a subdirectory within the target
                        directory

optional arguments:
  --project-name PROJECT_NAME
                        The name of your dbt project (as defined in
                        dbt_project.yml). Defaults to <my_client>
  --project-directory PROJECT_DIRECTORY
                        The name of your dbt project directory. Defaults to
                        <my-client>-dbt
  --profile-name PROFILE_NAME
                        The name of the profile your dbt project will use.
                        Defaults to <my_client>
```



Did not do:
* Add shorthand args, like `-c` for `--client` -- I initially did this, but reverted it because I think it makes more sense to type out the whole thing