### PR TITLE
fix/update dbt_utils to latest version

### DIFF
--- a/starter-project/dbt_project.yml
+++ b/starter-project/dbt_project.yml
@@ -4,7 +4,7 @@ profile: {{ project.profile_name }}
 
 version: '1.0'
 
-require-dbt-version: ">=0.15.0"
+require-dbt-version: ">=0.16.0"
 
 source-paths: ["models"]
 analysis-paths: ["analysis"]

--- a/starter-project/packages.yml
+++ b/starter-project/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - package: fishtown-analytics/dbt_utils
-    version: 0.1.24
+    version: 0.3.0


### PR DESCRIPTION
Update utils version in starter project to [`0.3.0`](https://hub.getdbt.com/fishtown-analytics/dbt_utils/latest/).

Also, per the [release notes](https://github.com/fishtown-analytics/dbt-utils/releases/tag/0.3.0), update `require-dbt-version` to 0.16.0 to be compatible with the 0.3.0 utils release
