### PR TITLE
update/bump up the utils package installed 

### DIFF
--- a/starter-project/packages.yml
+++ b/starter-project/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - package: fishtown-analytics/dbt_utils
-    version: 0.3.0
+    version: 0.6.4


### PR DESCRIPTION
The dbt utils package version that is being installed on most starter projects will be the one they get from dbt init. Bumping this up so it's on the latest version (I hope this is okay). 